### PR TITLE
Corrections to Composition Feature to view XML in device

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,23 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.capstone_project_intune">
     package="com.ymd.flutter_audio_capture">
    <application
         android:label="capstone_project_intune"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+
+<!--       <provider-->
+<!--           android:name="androidx.core.content.FileProvider"-->
+<!--           android:authorities="${applicationId}.fileProvider"-->
+<!--           android:exported="false"-->
+<!--           android:grantUriPermissions="true"-->
+<!--           tools:replace="android:authorities">-->
+<!--           <meta-data-->
+<!--               android:name="android.support.FILE_PROVIDER_PATHS"-->
+<!--               android:resource="@xml/filepaths"-->
+<!--               tools:replace="android:resource" />-->
+<!--       </provider>-->
         <activity
             android:requestLegacyExternalStorage="true"
             android:name=".MainActivity"

--- a/blank.musicxml
+++ b/blank.musicxml
@@ -17,7 +17,7 @@
                     <fifths>0</fifths>
                 </key>
                 <time>
-                    <beats>2</beats>
+                    <beats>4</beats>
                     <beat-type>4</beat-type>
                 </time>
                 <staves>1</staves>
@@ -27,7 +27,7 @@
                 </clef>
             </attributes>
             <note>
-                <rest measure="yes" />
+
                 <duration>8</duration>
                 <voice>1</voice>
                 <staff>1</staff>
@@ -35,30 +35,7 @@
             <backup>
                 <duration>8</duration>
             </backup>
-            <note>
-                 <pitch>
-                          <step></step>
-                          <octave></octave>
-                        </pitch>
-                        <duration>1</duration>
-                        <voice>1</voice>
-                        <type>eighth</type>
-                        <stem default-y="3">up</stem>
-                        <staff>1</staff>
-                        <beam number="1">begin</beam>
-            </note>
-             <note>
-                             <pitch>
-                                      <step></step>
-                                      <octave></octave>
-                                    </pitch>
-                                    <duration>1</duration>
-                                    <voice>1</voice>
-                                    <type>eighth</type>
-                                    <stem default-y="3">up</stem>
-                                    <staff>1</staff>
-                                    <beam number="1">begin</beam>
-                        </note>
+
 
 
         </measure>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,8 +29,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'InTune',
-      //home: Tuning(title: 'Tuning'),
-      home: on_change_practice(),
+      home: Tuning(title: 'Tuning'),
+      //home: on_change_practice(),
       debugShowCheckedModeBanner: false, //setup this property
     );
   }

--- a/lib/notes/music-line.dart
+++ b/lib/notes/music-line.dart
@@ -59,14 +59,14 @@ class _MusicLineState extends State<MusicLine> {
         children: <Widget>[
           Positioned(
             child: CustomPaint(
-              size: Size(newWidth, newHeight),
+              size: Size(newWidth, 500), //height hard coded to avoid infinite constraint error
               painter: BackgroundPainter(
                   widget.options, staffsSpacing),
             ),
           ),
           Positioned(
             child: CustomPaint(
-              size: Size(newWidth, newHeight),
+              size: Size(newWidth, 500), //height hard coded to avoid infinite constraint error
               painter: ForegroundPainter(
                   widget.options, staffsSpacing),
             ),

--- a/lib/practice.dart
+++ b/lib/practice.dart
@@ -8,6 +8,7 @@ import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_audio_capture/flutter_audio_capture.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:pitchupdart/instrument_type.dart';
 import 'package:pitchupdart/pitch_handler.dart';
 import 'package:xml/xml.dart';
@@ -19,6 +20,14 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:capstone_project_intune/ui/cloudFilePicker.dart';
+
+
+//read and write
+Future<void> writeToFile(ByteData data, String path) {
+  final buffer = data.buffer;
+  return new File(path).writeAsBytes(
+      buffer.asUint8List(data.offsetInBytes, data.lengthInBytes));
+}
 
 Future<Score> loadXML() async {
 /* // DOWNLOAD FILE FROM FIREBASE STORAGE TO UPLOAD INTO loadXML()
@@ -41,6 +50,9 @@ Future<Score> loadXML() async {
     final rawFile = await rootBundle.loadString('hanon-no1.musicxml');
     final result = parseMusicXML(XmlDocument.parse(rawFile));
     return result;
+
+
+
   // }
 }
 
@@ -103,7 +115,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Center(
               child: Container(
                 alignment: Alignment.center,
-                //width: size.width - 40,
+
                 //height: size.height - 20,
                 child: FutureBuilder<Score>(
                     future: loadXML(),
@@ -178,6 +190,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
 
+
   Future<void> _startCapture() async {
     await _audioRecorder.start(listener, onError,
         sampleRate: 44100, bufferSize: 3000);
@@ -185,7 +198,11 @@ class _MyHomePageState extends State<MyHomePage> {
     setState(() {
       note = "";
       status = "Play something";
+
     });
+
+
+
   }
 
   Future<void> _stopCapture() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -532,6 +532,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  open_file:
+    dependency: "direct main"
+    description:
+      name: open_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   signal_strength_indicator:
   convex_bottom_bar:
   flutter_sound: ^9.2.13
+  open_file: ^3.2.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Attempts to correct practice and composition features by writing assets to files in device application documents directory for user modification. Composition now has blank music sheet displayed and on stop capture, takes you to device documents to open composed file (test.xml) through html viewer, but notes added to composed file is not being written (current state broken).